### PR TITLE
Paid support costs

### DIFF
--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
@@ -135,12 +135,7 @@ code: |
   children.gather()
 
   nav.set_section("review_prior_order")
-  if has_existing_support_order:
-    current_child_support_signpost
-    who_paid
-    subtotal_amount
-    paid_child_care
-    paid_medical_costs
+  set_all_existing_support
 
   nav.set_section("review_agreement")
   if not agreed_on_who_pays:
@@ -183,6 +178,15 @@ code: |
       },
   )
   motion_child_support_download
+---
+code: |
+  if has_existing_support_order:
+    current_child_support_signpost
+    who_paid
+    subtotal_amount
+    paid_child_care
+    paid_medical_costs
+  set_all_existing_support = True
 ---
 id: intro screen
 question: |
@@ -921,17 +925,17 @@ attachment:
     - judgment_entered_date: ${ recent_judgment_date }
     - no_support_order: ${ not has_existing_support_order }
     - paid_support_costs: ${ has_existing_support_order }
-    - plaintiff_pays_support: ${ who_paid == "plaintiff" }
-    - defendant_pays_support:  ${ who_paid == "defendant" }
-    - support_amount: ${ thousands(subtotal_amount, show_decimals=True) }
-    - paid_child_care: ${ paid_child_care }
-    - plaintiff_pays_care: ${ paid_child_care and who_paid == "plaintiff" }
-    - defendant_pays_care: ${ paid_child_care and who_paid == "defendant" }
-    - child_care_amount: ${ thousands(child_care_amount if paid_child_care else "", show_decimals=True) }
-    - paid_medical_costs: ${ paid_medical_costs }
-    - plaintiff_pays_medical: ${ paid_medical_costs and who_paid == "plaintiff" }
-    - defendant_pays_medical: ${ paid_medical_costs and who_paid == "defendant" }
-    - medical_care_amount: ${ thousands(medical_care_amount if paid_medical_costs else "", show_decimals=True) }
+    - plaintiff_pays_support: ${ has_existing_support_order and who_paid == "plaintiff" }
+    - defendant_pays_support:  ${ has_existing_support_order and who_paid == "defendant" }
+    - support_amount: ${ thousands(subtotal_amount, show_decimals=True) if has_existing_support_order else "" }
+    - paid_child_care: ${ has_existing_support_order and paid_child_care }
+    - plaintiff_pays_care: ${ has_existing_support_order and paid_child_care and who_paid == "plaintiff" }
+    - defendant_pays_care: ${ has_existing_support_order and paid_child_care and who_paid == "defendant" }
+    - child_care_amount: ${ thousands(child_care_amount if paid_child_care else "", show_decimals=True) if has_existing_support_order else "" }
+    - paid_medical_costs: ${ has_existing_support_order and paid_medical_costs }
+    - plaintiff_pays_medical: ${ has_existing_support_order and paid_medical_costs and who_paid == "plaintiff" }
+    - defendant_pays_medical: ${ has_existing_support_order and paid_medical_costs and who_paid == "defendant" }
+    - medical_care_amount: ${ thousands(medical_care_amount if paid_medical_costs else "", show_decimals=True) if has_existing_support_order else "" }
     - conditions_have_changed: ${ have_circumstances_changed }
     - other_parties: ${ other_parties if agreed_on_who_pays else "" }
     - is_new_agreement: ${ agreed_on_who_pays }

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
@@ -920,8 +920,7 @@ attachment:
     - judgment_entered: ${ has_existing_support_order }
     - judgment_entered_date: ${ recent_judgment_date }
     - no_support_order: ${ not has_existing_support_order }
-    # TODO(#5): is this always true?
-    - paid_support_costs: True
+    - paid_support_costs: ${ has_existing_support_order }
     - plaintiff_pays_support: ${ who_paid == "plaintiff" }
     - defendant_pays_support:  ${ who_paid == "defendant" }
     - support_amount: ${ thousands(subtotal_amount, show_decimals=True) }

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
@@ -114,7 +114,9 @@ review:
 
       Was ${ plaintiffs[0].name.familiar() if who_paid == "plaintiff" else defendants[0].name.familiar() } ordered to pay monthly child care costs?: ${ word(yesno(paid_child_care)) }
 
+      % if paid_child_care:
       How much in child care costs were they ordered to pay per month?: ${ currency(showifdef('child_care_amount')) }
+      % endif
   - Edit: |-
       paid_medical_costs
     button: |
@@ -122,13 +124,36 @@ review:
 
       Was the ${ plaintiffs[0].name.familiar() if who_paid == "plaintiff" else defendants[0].name.familiar() } ordered to pay ordinary medical costs?: ${ word(yesno(paid_medical_costs)) }
 
+      % if paid_medical_costs:
       How much in ordinary medical costs were they ordered to pay per month?: ${ currency(showifdef('medical_care_amount')) }
+      % endif
+  - note: |
+      ---
+
+      <h2 class="h3">Agreement Information</h2>
   - Edit: |-
       agreed_on_who_pays
     button: |
       **Have you and ${ other_parties } agreed on who should pay support and how much?**
 
       ${ word(yesno(agreed_on_who_pays)) }
+  - Edit: |-
+      have_circumstances_changed
+    button: |
+      **Have circumstances changed?**
+
+      ${ word(yesno(have_circumstances_changed)) }
+  - Edit: |-
+      circumstance_changes
+    button: |
+      **How have your circumstances changed?**
+
+      ${ showifdef('circumstance_changes') }
+    show if: have_circumstances_changed
+  - note: |
+      ---
+
+      <h2 class="h3">Support Requested Information</h2>
   - Edit: |-
       who_pays_new
     button: |
@@ -164,30 +189,25 @@ review:
 
       ${ word(yesno(is_additional_amount_new)) }
 
+      % if is_additional_amount_new:
       Complete the following sentence. 'The reason for the other expenses is as follows:': ${ showifdef('additional_amount_reason') }
 
       How much per month are you asking the court to order for the other expenses?: ${ showifdef('additional_amount_new') }
+      % endif
   - Edit: |-
       asking_for_payer_benefits_credit
     button: |
+      % if agreed_on_who_pays:
       **In the agreement, are you asking the court to give the payer of child support a credit each month for dependent benefits received from a government insurance program?**
+      % else:
+      **Are you asking the court to give the payer of child support a credit each month for dependent benefits received from a government insurance program?**
+      % endif
 
       Are you asking for the court to give ${ who_pays_new } a credit?: ${ word(yesno(asking_for_payer_benefits_credit)) }
 
+      % if asking_for_payer_benefits_credit:
       How much is the monthly dependent benefit that the ${ "children get" if len(children) > 1 else "child gets" } from the government insurance program based on your work record?: ${ showifdef('child_benefit_amount') }
-  - Edit: |-
-      have_circumstances_changed
-    button: |
-      **Have circumstances changed?**
-
-      ${ word(yesno(have_circumstances_changed)) }
-  - Edit: |-
-      circumstance_changes
-    button: |
-      **How have your circumstances changed?**
-
-      ${ showifdef('circumstance_changes') }
-    show if: have_circumstances_changed
+      % endif
   - Edit: |-
       esign
     button: |

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
@@ -71,14 +71,6 @@ review:
       **What is your case number?**
 
       ${ showifdef('docket_number') }
-  - Edit: |-
-      has_existing_support_order
-    button: |
-      **Do you already have a child support order?**
-
-      Do you have a child support order in your case ${ docket_number }: ${ word(yesno(has_existing_support_order)) }
-
-      What date was the most recent judgment entered?: ${ showifdef('recent_judgment_date') }
   - label: Edit
     fields:
       - user_ask_role
@@ -88,6 +80,21 @@ review:
       **What party are you in your existing case?**
 
       ${ showifdef('user_ask_role') }
+  - note: |
+      ---
+
+      <h2 class="h3">Prior Support Order</h2>
+  - label: Edit
+    fields:
+      - has_existing_support_order
+      - recompute:
+        - set_all_existing_support
+    button: |
+      **Do you have a child support order in your case ${ docket_number }**: ${ word(yesno(has_existing_support_order)) }
+  - Edit: recent_judgment_date
+    button: |
+      **What date was the most recent judgment entered?**: ${ showifdef('recent_judgment_date') }
+    show if: has_existing_support_order
   - Edit: |-
       who_paid
     button: |


### PR DESCRIPTION
Fairly large change to the review screen as well:

* when `has_existing_support_order` is true, we assume that a few other values will be set. However, when changing on the review screen, that wasn't true. Needed to take a chunk out from the interview order and put it in it's own block, so we can recompute it from the review screen. Will ask those questions for the first time if they weren't asked going through the interview. Won't re-ask them if someone answered them, changed `has_existing_support_order` to False, and then back to True again, but IMO that's fine. They can still change those values on the review screen individually.
* Adds sections to the review screen that correspond to the sections in the interview
* Hides values that are show if'd on the page.