### PR TITLE
Review screen just help accordion

### DIFF
--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/motion_regarding_child_support.yml
@@ -2,6 +2,9 @@ include:
   - docassemble.AssemblyLine:assembly_line.yml
   - docassemble.mlhframework:mlh_interview_framework.yml
 ---
+modules:
+  - docassemble.demo.accordion
+---
 metadata:
   title: |
     Motion to Change or Get Child Support
@@ -87,23 +90,25 @@ code: |
   children[i].complete = True
 ---
 sections:
-  - review_intro: "Introduction"
-  - review_prior_case: "Prior Case Information"
-  - review_your_info: "Your Information"
-  - review_other_info: "Other Parent's Information"
-  - review_children_info: "Children Information"
-  - review_prior_order: "Prior Order Information"
-  - review_agreement: "Agreement Information"
-  - review_support_requested: "Support Requested Information"
-  - review_conclusion: "Conclusion"
+  - signpost_intro: "Introduction"
+  - signpost_prior_case: "Prior Case Information"
+  - signpost_your_info: "Your Information"
+  - signpost_other_info: "Other Parent's Information"
+  - signpost_children_info: "Children Information"
+  - signpost_prior_order: "Prior Order Information"
+  - signpost_agreement: "Agreement Information"
+  - signpost_support_requested: "Support Requested Information"
+  - signpost_download: "Get Your Forms"
+  - review_full: "✎ <u>Review / Edit</u>"
 ---
 id: interview_order_motion_regarding_child_support
 code: |
-  nav.set_section("review_intro")
+  nav.set_section("review_full")
+  nav.set_section("signpost_intro")
   intro_screen
   MLH_standard_intro_pages
 
-  nav.set_section("review_prior_case")
+  nav.set_section("signpost_prior_case")
   if not has_existing_case:
     existing_case_kickout
   what_you_will_need
@@ -123,29 +128,29 @@ code: |
   the_court
   docket_number
 
-  nav.set_section("review_your_info")
+  nav.set_section("signpost_your_info")
   user_started_case
   public_record_fyi
 
   users.gather()
-  nav.set_section("review_other_info")
+  nav.set_section("signpost_other_info")
   other_parties.gather()
-  nav.set_section("review_children_info")
+  nav.set_section("signpost_children_info")
   children.gather()
 
-  nav.set_section("review_prior_order")
+  nav.set_section("signpost_prior_order")
   set_all_existing_support
 
-  nav.set_section("review_agreement")
+  nav.set_section("signpost_agreement")
 
-  nav.set_section("review_support_requested")
+  nav.set_section("signpost_support_requested")
   support_formula_fyi
   who_pays_new
   base_support_matches_calc
   new_support_info
     
 
-  nav.set_section("review_conclusion")
+  nav.set_section("signpost_download")
   # TODO(#7): do we need hearing info?
   #if has_hearing_info:
   #  hearing_at_court
@@ -827,7 +832,7 @@ subquestion: |
   
   View, download and send your form below. Click the "Edit answers" button to fix any mistakes.
 
-  ${ action_button_html(url_action('review_form'), label='Edit answers', color='info') }
+  ${ action_button_html(url_action('review_full'), label='Edit answers', color='info') }
   
   ${ al_user_bundle.download_list_html() }
 

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
@@ -1,31 +1,4 @@
-event: review_intro
-code: review_form
----
-event: review_prior_case
-code: review_form
----
-event: review_your_info
-code: review_form
----
-event: review_other_info
-code: review_form
----
-event: review_children_info
-code: review_form
----
-event: review_prior_order
-code: review_form
----
-event: review_agreement
-code: review_form
----
-event: review_support_requested
-code: review_form
----
-event: review_conclusion
-code: review_form
----
-event: review_form
+event: review_full
 id: |-
   review screen
 
@@ -33,8 +6,15 @@ question: |-
   Review your answers
 
 review:
+  - raw html: |
+      ${ start_accordion('<h2 class="h5">How does this page work?</h2>') }
   - note: |
-      <h2 class="h3">Your Case Information</h2>
+      This page starts out blank. As you answer more questions, they will show up here. Then you can edit your answers.
+      
+      Some questions will not show up here. To change an answer that does not appear on this page, use the **Undo** button or start the interview again.    
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Your Case Information</h2>') }
+    show if: docket_number
   - Edit: users.revisit
     button: |-
       **You**
@@ -87,17 +67,16 @@ review:
       **What party are you in your existing case?**
 
       ${ showifdef('user_ask_role').capitalize() }
-  - note: |
-      ---
-
-      <h2 class="h3">Prior Support Order</h2>
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Prior Support Order</h2>') }
+    show if: has_existing_support_order or not has_existing_support_order
   - note: |
       % if has_existing_support_order:
       **You have an existing support order.** 
       % else:
       **You do NOT have an existing support order.**
       % endif
-      (If you need to change this answer, please start over from the beginning.)
+      (If you need to change this answer, please use the **Undo** button or start over from the beginning.)
   - Edit: recent_judgment_date
     button: |
       **What date was the most recent support order entered?**: ${ showifdef('recent_judgment_date') }
@@ -148,16 +127,15 @@ review:
       % if paid_medical_costs:
       How much ordinary medical costs were ordered per month?: ${ currency(showifdef('medical_care_amount')) }
       % endif
-  - note: |
-      ---
-
-      <h2 class="h3">Agreement Information</h2>
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Agreement Information</h2>') }
+    show if: agreed_on_who_pays or not agreed_on_who_pays
   - Edit:
       - agreed_on_who_pays
       - recompute:
         - circumstance_changes_update
     button: |
-      **Have you and ${ other_parties } agreed on who should pay support and how much?**
+      **Have you and the other parent agreed on who should pay support and how much?**
 
       ${ word(yesno(agreed_on_who_pays)) }
   - Edit:
@@ -175,10 +153,9 @@ review:
 
       ${ showifdef('circumstance_changes') }
     show if: have_circumstances_changed
-  - note: |
-      ---
-
-      <h2 class="h3">Support Requested Information</h2>
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Support Requested Information</h2>') }
+    show if: who_pays_new
   - label: Edit
     fields:
       - who_pays_new
@@ -260,37 +237,8 @@ review:
       esign
     button: |
       **Would you like to add your electronic signature to your form?**: ${ word(yesno(esign)) }
-  - Edit: |-
-      has_hearing_info
-    button: |
-      **Motion Hearing Information**
-
-      ${ word(yesno(has_hearing_info)) }
-  - Edit: |-
-      hearing_date
-    button: |
-      **When will the hearing be?**
-
-      Date of hearing: ${ showifdef('hearing_date') }
-
-      Hearing Time: ${ showifdef('hearing_time') }
-  - Edit: |-
-      hearing_at_court
-    button: |
-      **Where will the hearing be?**
-
-      Will the hearing be in person at the courthouse?: ${ word(yesno(hearing_at_court)) }
-
-      * Type the address if it will be at a physical location. * If the hearing will be online or by phone, briefly explain.: ${ showifdef('hearing_address_on_one_line') }
-  - Edit: |-
-      judge.name
-    button: |
-      **What judge will hear your motion?**
-
-      Judge's name: ${ showifdef('judge.name') }
-
-      Judge's bar number: ${ showifdef('judge_bar_number') }
-
+  - raw html: |
+      ${ end_accordion() }
 ---
 id: revisit users
 question: Edit your answers about yourself

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
@@ -135,7 +135,7 @@ review:
       ---
 
       <h2 class="h3">Agreement Information</h2>
-    show if: agreed_on_who_pays
+    show if: agreed_on_who_pays or not agreed_on_who_pays
   - Edit:
       - agreed_on_who_pays
       - recompute:

--- a/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
+++ b/docassemble/MLHMotionRegardingChildSupport/data/questions/review.yml
@@ -13,7 +13,9 @@ review:
       
       Some questions will not show up here. To change an answer that does not appear on this page, use the **Undo** button or start the interview again.    
   - raw html: |
-      ${ next_accordion('<h2 class="h5">Your Case Information</h2>') }
+      ${ end_accordion() }
+  - note: |
+      <h2 class="h3">Your Case Information</h2>
     show if: docket_number
   - Edit: users.revisit
     button: |-
@@ -67,8 +69,10 @@ review:
       **What party are you in your existing case?**
 
       ${ showifdef('user_ask_role').capitalize() }
-  - raw html: |
-      ${ next_accordion('<h2 class="h5">Prior Support Order</h2>') }
+  - note: |
+      ---
+
+      <h2 class="h3">Prior Support Order</h2>
     show if: has_existing_support_order or not has_existing_support_order
   - note: |
       % if has_existing_support_order:
@@ -127,9 +131,11 @@ review:
       % if paid_medical_costs:
       How much ordinary medical costs were ordered per month?: ${ currency(showifdef('medical_care_amount')) }
       % endif
-  - raw html: |
-      ${ next_accordion('<h2 class="h5">Agreement Information</h2>') }
-    show if: agreed_on_who_pays or not agreed_on_who_pays
+  - note: |
+      ---
+
+      <h2 class="h3">Agreement Information</h2>
+    show if: agreed_on_who_pays
   - Edit:
       - agreed_on_who_pays
       - recompute:
@@ -153,8 +159,10 @@ review:
 
       ${ showifdef('circumstance_changes') }
     show if: have_circumstances_changed
-  - raw html: |
-      ${ next_accordion('<h2 class="h5">Support Requested Information</h2>') }
+  - note: |
+      ---
+
+      <h2 class="h3">Support Requested Information</h2>
     show if: who_pays_new
   - label: Edit
     fields:
@@ -237,8 +245,6 @@ review:
       esign
     button: |
       **Would you like to add your electronic signature to your form?**: ${ word(yesno(esign)) }
-  - raw html: |
-      ${ end_accordion() }
 ---
 id: revisit users
 question: Edit your answers about yourself


### PR DESCRIPTION
In this branch, I just made the help info an accordion. Other sections appear as normal (but headings only appear if they have contents).

When you start interview:
![image](https://github.com/mplp/docassemble-MLHMotionRegardingChildSupport/assets/110936328/c8967576-1c74-4587-a031-612e24360ba2)
![image](https://github.com/mplp/docassemble-MLHMotionRegardingChildSupport/assets/110936328/4c67c52d-0588-45ed-99dc-fe0c241c3ae4)

Further along in interview:
![image](https://github.com/mplp/docassemble-MLHMotionRegardingChildSupport/assets/110936328/f201cc68-d452-4e7e-b374-4ccab2bc2f62)
